### PR TITLE
feat: multi-camera support (closes #35)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ custom_components/webrtc/
 
 # Git worktrees
 .worktrees/
+
+# uv package manager
+uv.lock

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Home Assistant integration for Philips Avent SCD973/SCD923 baby monitors, provid
 | 🔊 Sound Detected | Binary Sensor | Fires when sound is detected (auto-clears after 30s) |
 | 🔒 Privacy Mode | Switch | Camera on/off |
 
+Multiple monitors on one Tuya account are supported: the bridge serves each camera from the same port on a distinct RTSP path derived from the camera's display name.
+
 ## Installation
 
 ### Integration (HACS)
@@ -114,8 +116,10 @@ The integration uses the same Tuya Mobile SDK API as the official Philips Avent 
 │  └────────────────────────┘  │
 │                              │
 │  ┌────────────────────────┐  │
-│  │  Camera Entity         │  │
-│  │  rtsp://...:8554/Name  │  │
+│  │  Camera Entities       │  │
+│  │  rtsp://host:38554/N1  │  │
+│  │  rtsp://host:38554/N2  │  │
+│  │  ...                   │  │
 │  └────────────────────────┘  │
 └─────────────────────────────┘
 ```

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The integration uses the same Tuya Mobile SDK API as the official Philips Avent 
 │  ┌────────────────────────┐  │
 │  │  Bridge Add-on         │  │   Camera
 │  │  (WebRTC → RTSP)       │◄─┼──► via STUN/TURN
-│  │  :8554                 │  │   (1080p H.264)
+│  │  :38554                │  │   (1080p H.264)
 │  └────────────────────────┘  │
 │                              │
 │  ┌────────────────────────┐  │

--- a/avent-webrtc-bridge/cmd/addon/addon.go
+++ b/avent-webrtc-bridge/cmd/addon/addon.go
@@ -4,9 +4,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
 
 	"avent-webrtc-bridge/pkg/core"
+	"avent-webrtc-bridge/pkg/rtsp"
 	"avent-webrtc-bridge/pkg/storage"
+	"avent-webrtc-bridge/pkg/tuya"
 )
 
 // BridgeConfig is the JSON shape written by the HA integration
@@ -107,5 +115,121 @@ func validateConfig(cfg BridgeConfig) error {
 	if len(cfg.Cameras) == 0 {
 		return fmt.Errorf("cameras list is empty: nothing to serve")
 	}
+	return nil
+}
+
+var storageManager *storage.StorageManager
+
+func SetStorageManager(sm *storage.StorageManager) {
+	storageManager = sm
+}
+
+func NewAddonCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "addon",
+		Short: "Run the multi-camera bridge driven by the HA integration JSON",
+		Long: `Read the bridge config JSON written by the Philips Avent HA integration
+and serve every camera under it from one RTSP server, each on its own path.
+
+Example:
+  avent-webrtc-bridge addon --config /config/philips_avent_bridge_<entry_id>.json`,
+		RunE: runAddon,
+	}
+	cmd.Flags().String("config", "", "Path to the bridge config JSON written by the HA integration")
+	cmd.MarkFlagRequired("config")
+	return cmd
+}
+
+func runAddon(cmd *cobra.Command, args []string) error {
+	cfgPath, _ := cmd.Flags().GetString("config")
+
+	cfg, err := loadConfig(cfgPath)
+	if err != nil {
+		return err
+	}
+	if err := validateConfig(cfg); err != nil {
+		return fmt.Errorf("invalid config %s: %w", cfgPath, err)
+	}
+
+	port := cfg.BridgePort
+	if port == 0 {
+		port = 38554
+	}
+
+	client := tuya.NewMobileSDKClient(cfg.SigningKey, cfg.SID, cfg.AppKey, cfg.DeviceID, "071d81fa")
+	client.Ecode = cfg.Ecode
+	client.PartnerIdentity = cfg.Partner
+	client.PackageName = cfg.PackageName
+
+	core.Logger.Info().Msg("Verifying API access...")
+	if _, err := client.Call("smartlife.p.time.get", "1.0", nil); err != nil {
+		return fmt.Errorf("API verification failed: %w", err)
+	}
+	core.Logger.Info().Msg("API access OK")
+
+	userInfo, err := client.GetUserInfo()
+	if err != nil {
+		return fmt.Errorf("get user info: %w", err)
+	}
+	core.Logger.Info().Msgf("User: %s (%s)", userInfo.Nickname, userInfo.Email)
+	client.UID = userInfo.ID
+
+	userKey := "addon_" + strings.ReplaceAll(strings.ReplaceAll(userInfo.Email, "@", "_at_"), ".", "_")
+	user := &storage.UserSession{
+		Email:  userInfo.Email,
+		Region: "addon",
+		SessionData: &tuya.SessionData{
+			LoginResult: &tuya.LoginResult{
+				Uid:      userInfo.ID,
+				Email:    userInfo.Email,
+				Nickname: userInfo.Nickname,
+				Domain:   userInfo.Domain,
+			},
+			ServerHost: "a1.tuyaeu.com",
+			Region:     "addon",
+			UserEmail:  userInfo.Email,
+		},
+		LastRefresh: time.Now(),
+		UserKey:     userKey,
+	}
+	if err := storageManager.SaveUser("addon", userInfo.Email, user.SessionData); err != nil {
+		core.Logger.Warn().Msgf("Could not save user session: %v", err)
+	}
+
+	camsWithPath := assignPaths(cfg.Cameras)
+	if len(camsWithPath) == 0 {
+		return fmt.Errorf("no valid cameras after filtering, refusing to start")
+	}
+
+	infos := make([]storage.CameraInfo, 0, len(camsWithPath))
+	pathLog := make([]string, 0, len(camsWithPath))
+	for _, c := range camsWithPath {
+		infos = append(infos, storage.CameraInfo{
+			DeviceID:   c.ID,
+			DeviceName: c.Name,
+			Category:   "sp",
+			RTSPPath:   c.Path,
+			UserKey:    userKey,
+		})
+		pathLog = append(pathLog, c.Path)
+		core.Logger.Info().Msgf("Camera registered: id=%s name=%s path=%s", c.ID, c.Name, c.Path)
+	}
+	if err := storageManager.UpdateCamerasForUser(userKey, infos); err != nil {
+		core.Logger.Warn().Msgf("Could not save cameras: %v", err)
+	}
+
+	server := rtsp.NewRTSPServer(port, storageManager)
+	server.MobileClient = client
+	if err := server.Start(); err != nil {
+		return fmt.Errorf("start RTSP server: %w", err)
+	}
+	core.Logger.Info().Msgf("Serving %d cameras on port %d: %s", len(infos), port, strings.Join(pathLog, " "))
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	<-sigChan
+
+	core.Logger.Info().Msg("Shutting down...")
+	server.Stop()
 	return nil
 }

--- a/avent-webrtc-bridge/cmd/addon/addon.go
+++ b/avent-webrtc-bridge/cmd/addon/addon.go
@@ -37,3 +37,28 @@ func loadConfig(path string) (BridgeConfig, error) {
 	}
 	return cfg, nil
 }
+
+func validateConfig(cfg BridgeConfig) error {
+	if cfg.SigningKey == "" {
+		return fmt.Errorf("signing_key is required")
+	}
+	if cfg.SID == "" {
+		return fmt.Errorf("sid is required")
+	}
+	if cfg.AppKey == "" {
+		return fmt.Errorf("app_key is required")
+	}
+	if cfg.DeviceID == "" {
+		return fmt.Errorf("device_id is required")
+	}
+	if cfg.Ecode == "" {
+		return fmt.Errorf("ecode is required")
+	}
+	if cfg.Partner == "" {
+		return fmt.Errorf("partner is required")
+	}
+	if len(cfg.Cameras) == 0 {
+		return fmt.Errorf("cameras list is empty: nothing to serve")
+	}
+	return nil
+}

--- a/avent-webrtc-bridge/cmd/addon/addon.go
+++ b/avent-webrtc-bridge/cmd/addon/addon.go
@@ -1,0 +1,39 @@
+package addon
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// BridgeConfig is the JSON shape written by the HA integration
+// in custom_components/philips_avent/__init__.py::_write_bridge_config.
+type BridgeConfig struct {
+	SigningKey   string   `json:"signing_key"`
+	SID         string   `json:"sid"`
+	Ecode       string   `json:"ecode"`
+	Partner     string   `json:"partner"`
+	AppKey      string   `json:"app_key"`
+	DeviceID    string   `json:"device_id"`
+	PackageName string   `json:"package_name"`
+	BridgePort  int      `json:"bridge_port"`
+	Cameras     []Camera `json:"cameras"`
+}
+
+// Camera is one entry under "cameras" in the JSON.
+type Camera struct {
+	ID   string `json:"camera_id"`
+	Name string `json:"camera_name"`
+}
+
+func loadConfig(path string) (BridgeConfig, error) {
+	var cfg BridgeConfig
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cfg, fmt.Errorf("read %s: %w", path, err)
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return cfg, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return cfg, nil
+}

--- a/avent-webrtc-bridge/cmd/addon/addon.go
+++ b/avent-webrtc-bridge/cmd/addon/addon.go
@@ -15,6 +15,7 @@ import (
 	"avent-webrtc-bridge/pkg/rtsp"
 	"avent-webrtc-bridge/pkg/storage"
 	"avent-webrtc-bridge/pkg/tuya"
+	"avent-webrtc-bridge/pkg/utils"
 )
 
 // BridgeConfig is the JSON shape written by the HA integration
@@ -77,15 +78,20 @@ func assignPaths(cams []Camera) []CameraWithPath {
 		}
 		seenIDs[cam.ID] = true
 
-		path := storage.SanitizeRTSPPath(cam.Name, cam.ID)
+		basePath := storage.SanitizeRTSPPath(cam.Name, cam.ID)
+		path := basePath
 		if seenPaths[path] {
 			suffix := cam.ID
 			if len(suffix) > 6 {
 				suffix = suffix[:6]
 			}
-			collided := path + "_" + suffix
-			core.Logger.Warn().Msgf("Path collision on %s, falling back to %s", path, collided)
-			path = collided
+			path = basePath + "_" + suffix
+			i := 2
+			for seenPaths[path] {
+				path = fmt.Sprintf("%s_%s_%d", basePath, suffix, i)
+				i++
+			}
+			core.Logger.Warn().Msgf("Path collision on %s, falling back to %s", basePath, path)
 		}
 		seenPaths[path] = true
 		out = append(out, CameraWithPath{Camera: cam, Path: path})
@@ -171,7 +177,7 @@ func runAddon(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("get user info: %w", err)
 	}
-	core.Logger.Info().Msgf("User: %s (%s)", userInfo.Nickname, userInfo.Email)
+	core.Logger.Info().Msgf("User: %s (%s)", userInfo.Nickname, utils.MaskEmail(userInfo.Email))
 	client.UID = userInfo.ID
 
 	userKey := "addon_" + strings.ReplaceAll(strings.ReplaceAll(userInfo.Email, "@", "_at_"), ".", "_")

--- a/avent-webrtc-bridge/cmd/addon/addon.go
+++ b/avent-webrtc-bridge/cmd/addon/addon.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+
+	"avent-webrtc-bridge/pkg/core"
+	"avent-webrtc-bridge/pkg/storage"
 )
 
 // BridgeConfig is the JSON shape written by the HA integration
@@ -36,6 +39,50 @@ func loadConfig(path string) (BridgeConfig, error) {
 		return cfg, fmt.Errorf("parse %s: %w", path, err)
 	}
 	return cfg, nil
+}
+
+// CameraWithPath pairs a Camera with the RTSP path it will be served on.
+type CameraWithPath struct {
+	Camera
+	Path string
+}
+
+// assignPaths sanitizes each camera's name into an RTSP path and filters out
+// invalid entries. Behavior:
+//   - skip entries with empty camera_id (warn);
+//   - skip later entries that repeat a previously-seen camera_id (warn) — a single
+//     physical device must not be registered twice;
+//   - when two distinct cameras sanitize to the same path, the second one gets
+//     a suffix derived from up to 6 characters of its camera_id (warn).
+func assignPaths(cams []Camera) []CameraWithPath {
+	out := make([]CameraWithPath, 0, len(cams))
+	seenIDs := make(map[string]bool, len(cams))
+	seenPaths := make(map[string]bool, len(cams))
+	for _, cam := range cams {
+		if cam.ID == "" {
+			core.Logger.Warn().Msgf("Camera config invalid: missing camera_id, skipping name=%q", cam.Name)
+			continue
+		}
+		if seenIDs[cam.ID] {
+			core.Logger.Warn().Msgf("Duplicate camera_id %q, skipping repeated entry name=%q", cam.ID, cam.Name)
+			continue
+		}
+		seenIDs[cam.ID] = true
+
+		path := storage.SanitizeRTSPPath(cam.Name, cam.ID)
+		if seenPaths[path] {
+			suffix := cam.ID
+			if len(suffix) > 6 {
+				suffix = suffix[:6]
+			}
+			collided := path + "_" + suffix
+			core.Logger.Warn().Msgf("Path collision on %s, falling back to %s", path, collided)
+			path = collided
+		}
+		seenPaths[path] = true
+		out = append(out, CameraWithPath{Camera: cam, Path: path})
+	}
+	return out
 }
 
 func validateConfig(cfg BridgeConfig) error {

--- a/avent-webrtc-bridge/cmd/addon/addon_test.go
+++ b/avent-webrtc-bridge/cmd/addon/addon_test.go
@@ -115,3 +115,84 @@ func TestValidateConfig_RejectsMissingPartner(t *testing.T) {
 		t.Fatal("want error for missing partner")
 	}
 }
+
+func TestAssignPaths_NoCollision(t *testing.T) {
+	cams := []Camera{
+		{ID: "abc123", Name: "Erik"},
+		{ID: "def456", Name: "Anna"},
+	}
+	out := assignPaths(cams)
+	if len(out) != 2 {
+		t.Fatalf("got %d, want 2", len(out))
+	}
+	if out[0].Path != "/Erik" {
+		t.Errorf("out[0].Path = %q, want /Erik", out[0].Path)
+	}
+	if out[1].Path != "/Anna" {
+		t.Errorf("out[1].Path = %q, want /Anna", out[1].Path)
+	}
+}
+
+func TestAssignPaths_CollidingNames(t *testing.T) {
+	cams := []Camera{
+		{ID: "abc123", Name: "Baby"},
+		{ID: "def456", Name: "Baby"},
+	}
+	out := assignPaths(cams)
+	if len(out) != 2 {
+		t.Fatalf("got %d, want 2", len(out))
+	}
+	if out[0].Path != "/Baby" {
+		t.Errorf("first kept as-is: got %q", out[0].Path)
+	}
+	if out[1].Path != "/Baby_def456" {
+		t.Errorf("second got suffix: got %q, want /Baby_def456", out[1].Path)
+	}
+}
+
+func TestAssignPaths_ShortIDCollision(t *testing.T) {
+	cams := []Camera{
+		{ID: "ab", Name: "X"},
+		{ID: "cd", Name: "X"},
+	}
+	out := assignPaths(cams)
+	if len(out) != 2 {
+		t.Fatalf("got %d, want 2", len(out))
+	}
+	if out[1].Path != "/X_cd" {
+		t.Errorf("got %q, want /X_cd (short id used in full)", out[1].Path)
+	}
+}
+
+func TestAssignPaths_DuplicateCameraID(t *testing.T) {
+	// Different names per duplicate to make the "first entry wins" contract explicit.
+	cams := []Camera{
+		{ID: "abc123", Name: "Erik"},
+		{ID: "abc123", Name: "Renamed Erik"},
+		{ID: "def456", Name: "Anna"},
+	}
+	out := assignPaths(cams)
+	if len(out) != 2 {
+		t.Fatalf("got %d, want 2 (the second 'abc123' should be skipped)", len(out))
+	}
+	if out[0].ID != "abc123" || out[0].Name != "Erik" {
+		t.Errorf("first occurrence should win, got %+v", out[0])
+	}
+	if out[1].ID != "def456" {
+		t.Errorf("third entry should follow: %+v", out[1])
+	}
+}
+
+func TestAssignPaths_SkipsMissingID(t *testing.T) {
+	cams := []Camera{
+		{ID: "", Name: "Ghost"},
+		{ID: "abc123", Name: "Erik"},
+	}
+	out := assignPaths(cams)
+	if len(out) != 1 {
+		t.Fatalf("got %d, want 1 (entry with empty ID should be skipped)", len(out))
+	}
+	if out[0].ID != "abc123" {
+		t.Errorf("kept the wrong entry: %+v", out)
+	}
+}

--- a/avent-webrtc-bridge/cmd/addon/addon_test.go
+++ b/avent-webrtc-bridge/cmd/addon/addon_test.go
@@ -164,6 +164,37 @@ func TestAssignPaths_ShortIDCollision(t *testing.T) {
 	}
 }
 
+func TestAssignPaths_CascadingFallback(t *testing.T) {
+	// Three cameras sharing the same name AND the same first 6 chars of camera_id.
+	// The naive single-step fallback would produce three identical "/Baby_abcdef"
+	// paths; the loop must extend the suffix with a counter to keep them unique.
+	cams := []Camera{
+		{ID: "abcdef01", Name: "Baby"},
+		{ID: "abcdef02", Name: "Baby"},
+		{ID: "abcdef03", Name: "Baby"},
+	}
+	out := assignPaths(cams)
+	if len(out) != 3 {
+		t.Fatalf("got %d, want 3", len(out))
+	}
+	paths := map[string]bool{}
+	for _, c := range out {
+		if paths[c.Path] {
+			t.Fatalf("duplicate fallback path %q in %+v", c.Path, out)
+		}
+		paths[c.Path] = true
+	}
+	if out[0].Path != "/Baby" {
+		t.Errorf("first kept as base: got %q", out[0].Path)
+	}
+	if out[1].Path != "/Baby_abcdef" {
+		t.Errorf("second got single-suffix: got %q, want /Baby_abcdef", out[1].Path)
+	}
+	if out[2].Path != "/Baby_abcdef_2" {
+		t.Errorf("third got counter suffix: got %q, want /Baby_abcdef_2", out[2].Path)
+	}
+}
+
 func TestAssignPaths_DuplicateCameraID(t *testing.T) {
 	// Different names per duplicate to make the "first entry wins" contract explicit.
 	cams := []Camera{

--- a/avent-webrtc-bridge/cmd/addon/addon_test.go
+++ b/avent-webrtc-bridge/cmd/addon/addon_test.go
@@ -1,0 +1,49 @@
+package addon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfig_ValidTwoCameras(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "bridge.json")
+	body := `{
+	  "signing_key": "sk",
+	  "sid": "S",
+	  "ecode": "E",
+	  "partner": "P",
+	  "app_key": "AK",
+	  "device_id": "D",
+	  "package_name": "pkg",
+	  "bridge_port": 38554,
+	  "cameras": [
+	    {"camera_id": "abc123", "camera_name": "Erik"},
+	    {"camera_id": "def456", "camera_name": "Anna"}
+	  ]
+	}`
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := loadConfig(p)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.SigningKey != "sk" || cfg.SID != "S" || cfg.AppKey != "AK" {
+		t.Errorf("creds parsed wrong: %+v", cfg)
+	}
+	if cfg.BridgePort != 38554 {
+		t.Errorf("port = %d, want 38554", cfg.BridgePort)
+	}
+	if len(cfg.Cameras) != 2 {
+		t.Fatalf("cameras = %d, want 2", len(cfg.Cameras))
+	}
+	if cfg.Cameras[0].ID != "abc123" || cfg.Cameras[0].Name != "Erik" {
+		t.Errorf("camera[0] = %+v", cfg.Cameras[0])
+	}
+	if cfg.Cameras[1].ID != "def456" || cfg.Cameras[1].Name != "Anna" {
+		t.Errorf("camera[1] = %+v", cfg.Cameras[1])
+	}
+}

--- a/avent-webrtc-bridge/cmd/addon/addon_test.go
+++ b/avent-webrtc-bridge/cmd/addon/addon_test.go
@@ -47,3 +47,71 @@ func TestLoadConfig_ValidTwoCameras(t *testing.T) {
 		t.Errorf("camera[1] = %+v", cfg.Cameras[1])
 	}
 }
+
+func TestLoadConfig_MalformedJSON(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "bridge.json")
+	if err := os.WriteFile(p, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadConfig(p); err == nil {
+		t.Fatal("want error for malformed JSON, got nil")
+	}
+}
+
+func TestLoadConfig_MissingFile(t *testing.T) {
+	if _, err := loadConfig("/nonexistent/path.json"); err == nil {
+		t.Fatal("want error for missing file, got nil")
+	}
+}
+
+func TestValidateConfig_RejectsMissingCreds(t *testing.T) {
+	cfg := BridgeConfig{Cameras: []Camera{{ID: "abc", Name: "Erik"}}}
+	if err := validateConfig(cfg); err == nil {
+		t.Fatal("want error for missing signing_key")
+	}
+}
+
+func TestValidateConfig_RejectsEmptyCameras(t *testing.T) {
+	cfg := BridgeConfig{
+		SigningKey: "sk", SID: "S", AppKey: "AK", DeviceID: "D",
+		Ecode: "E", Partner: "P",
+		Cameras: []Camera{},
+	}
+	if err := validateConfig(cfg); err == nil {
+		t.Fatal("want error for empty cameras")
+	}
+}
+
+func TestValidateConfig_AcceptsMinimal(t *testing.T) {
+	cfg := BridgeConfig{
+		SigningKey: "sk", SID: "S", AppKey: "AK", DeviceID: "D",
+		Ecode: "E", Partner: "P",
+		Cameras: []Camera{{ID: "abc", Name: "Erik"}},
+	}
+	if err := validateConfig(cfg); err != nil {
+		t.Fatalf("validateConfig: unexpected error %v", err)
+	}
+}
+
+func TestValidateConfig_RejectsMissingEcode(t *testing.T) {
+	cfg := BridgeConfig{
+		SigningKey: "sk", SID: "S", AppKey: "AK", DeviceID: "D",
+		Partner: "P",
+		Cameras: []Camera{{ID: "abc", Name: "Erik"}},
+	}
+	if err := validateConfig(cfg); err == nil {
+		t.Fatal("want error for missing ecode")
+	}
+}
+
+func TestValidateConfig_RejectsMissingPartner(t *testing.T) {
+	cfg := BridgeConfig{
+		SigningKey: "sk", SID: "S", AppKey: "AK", DeviceID: "D",
+		Ecode: "E",
+		Cameras: []Camera{{ID: "abc", Name: "Erik"}},
+	}
+	if err := validateConfig(cfg); err == nil {
+		t.Fatal("want error for missing partner")
+	}
+}

--- a/avent-webrtc-bridge/cmd/direct/direct.go
+++ b/avent-webrtc-bridge/cmd/direct/direct.go
@@ -76,10 +76,7 @@ func runDirect(cmd *cobra.Command, args []string) error {
 	cameraName, _ := cmd.Flags().GetString("camera-name")
 	port, _ := cmd.Flags().GetInt("port")
 
-	if cameraName == "" {
-		cameraName = cameraID
-	}
-	rtspPath := "/" + strings.ReplaceAll(cameraName, " ", "_")
+	rtspPath := storage.SanitizeRTSPPath(cameraName, cameraID)
 
 	client := tuya.NewMobileSDKClient(signingKey, sid, appKey, deviceID, chKey)
 	client.Ecode = ecode

--- a/avent-webrtc-bridge/cmd/direct/direct.go
+++ b/avent-webrtc-bridge/cmd/direct/direct.go
@@ -14,6 +14,7 @@ import (
 	"avent-webrtc-bridge/pkg/rtsp"
 	"avent-webrtc-bridge/pkg/storage"
 	"avent-webrtc-bridge/pkg/tuya"
+	"avent-webrtc-bridge/pkg/utils"
 )
 
 var storageManager *storage.StorageManager
@@ -94,7 +95,7 @@ func runDirect(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get user info: %v", err)
 	}
-	core.Logger.Info().Msgf("User: %s (%s)", userInfo.Nickname, userInfo.Email)
+	core.Logger.Info().Msgf("User: %s (%s)", userInfo.Nickname, utils.MaskEmail(userInfo.Email))
 	core.Logger.Info().Msgf("MQTT domain: %s", userInfo.Domain.MobileMqttsUrl)
 	client.UID = userInfo.ID
 
@@ -140,8 +141,8 @@ func runDirect(cmd *cobra.Command, args []string) error {
 	}
 
 	core.Logger.Info().Msgf("RTSP endpoints:")
-	core.Logger.Info().Msgf("  HD: rtsp://localhost:%d/%s", port, rtspPath)
-	core.Logger.Info().Msgf("  SD: rtsp://localhost:%d/%s/sd", port, rtspPath)
+	core.Logger.Info().Msgf("  HD: rtsp://localhost:%d%s", port, rtspPath)
+	core.Logger.Info().Msgf("  SD: rtsp://localhost:%d%s/sd", port, rtspPath)
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)

--- a/avent-webrtc-bridge/cmd/root.go
+++ b/avent-webrtc-bridge/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"avent-webrtc-bridge/cmd/addon"
 	"avent-webrtc-bridge/cmd/auth"
 	"avent-webrtc-bridge/cmd/cameras"
 	"avent-webrtc-bridge/cmd/direct"
@@ -47,6 +48,7 @@ func init() {
 	rootCmd.AddCommand(cameras.NewCamerasCmd())
 	rootCmd.AddCommand(rtsp.NewRTSPCmd())
 	rootCmd.AddCommand(direct.NewDirectCmd())
+	rootCmd.AddCommand(addon.NewAddonCmd())
 }
 
 func initConfig() {
@@ -62,6 +64,7 @@ func initConfig() {
 	cameras.SetStorageManager(storageManager)
 	rtsp.SetStorageManager(storageManager)
 	direct.SetStorageManager(storageManager)
+	addon.SetStorageManager(storageManager)
 }
 
 func GetStorageManager() *storage.StorageManager {

--- a/avent-webrtc-bridge/pkg/storage/manager.go
+++ b/avent-webrtc-bridge/pkg/storage/manager.go
@@ -244,17 +244,7 @@ func (sm *StorageManager) GetAllCameras() ([]CameraInfo, error) {
 }
 
 func (sm *StorageManager) GenerateRTSPPath(deviceName, deviceID string) string {
-	// Clean device name for URL safety
-	safeName := strings.ReplaceAll(deviceName, " ", "_")
-	safeName = strings.ReplaceAll(safeName, "/", "_")
-	safeName = strings.ReplaceAll(safeName, "\\", "_")
-
-	// If name is empty or too generic, use device ID
-	if safeName == "" || safeName == "_" {
-		safeName = deviceID
-	}
-
-	return fmt.Sprintf("/%s", safeName)
+	return SanitizeRTSPPath(deviceName, deviceID)
 }
 
 func (sm *StorageManager) ValidateUserSession(region, email string) (bool, error) {

--- a/avent-webrtc-bridge/pkg/storage/path.go
+++ b/avent-webrtc-bridge/pkg/storage/path.go
@@ -1,0 +1,20 @@
+package storage
+
+import "strings"
+
+// SanitizeRTSPPath converts a camera display name into an RTSP path component.
+// It replaces spaces, forward slashes, and backslashes with underscores.
+// If the result is empty or just "_", falls back to the camera id.
+// The returned string starts with "/".
+func SanitizeRTSPPath(name, id string) string {
+	sanitized := strings.ReplaceAll(name, " ", "_")
+	sanitized = strings.ReplaceAll(sanitized, "/", "_")
+	sanitized = strings.ReplaceAll(sanitized, "\\", "_")
+
+	// If name is empty or too generic, use device ID
+	if sanitized == "" || sanitized == "_" {
+		sanitized = id
+	}
+
+	return "/" + sanitized
+}

--- a/avent-webrtc-bridge/pkg/storage/path_test.go
+++ b/avent-webrtc-bridge/pkg/storage/path_test.go
@@ -1,0 +1,36 @@
+package storage
+
+import "testing"
+
+func TestSanitizeRTSPPath(t *testing.T) {
+	cases := []struct {
+		name string
+		in   struct{ name, id string }
+		want string
+	}{
+		{"simple name", struct{ name, id string }{"Erik", "abc123"}, "/Erik"},
+		{"name with spaces", struct{ name, id string }{"Baby Room", "abc123"}, "/Baby_Room"},
+		{"empty name falls back to id", struct{ name, id string }{"", "abc123"}, "/abc123"},
+		{"multiple spaces", struct{ name, id string }{"Erik  Two", "abc123"}, "/Erik__Two"},
+		{"slash in name", struct{ name, id string }{"Room/Camera", "abc123"}, "/Room_Camera"},
+		{"backslash in name", struct{ name, id string }{"Room\\Camera", "abc123"}, "/Room_Camera"},
+		{"name sanitizes to underscore", struct{ name, id string }{"/", "abc123"}, "/abc123"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := SanitizeRTSPPath(c.in.name, c.in.id)
+			if got != c.want {
+				t.Errorf("SanitizeRTSPPath(%q, %q) = %q, want %q", c.in.name, c.in.id, got, c.want)
+			}
+		})
+	}
+}
+
+func TestGenerateRTSPPath_delegatesToSanitize(t *testing.T) {
+	sm := &StorageManager{}
+	got := sm.GenerateRTSPPath("Baby Room", "dev456")
+	want := SanitizeRTSPPath("Baby Room", "dev456")
+	if got != want {
+		t.Errorf("GenerateRTSPPath(%q, %q) = %q, want %q", "Baby Room", "dev456", got, want)
+	}
+}

--- a/avent-webrtc-bridge/pkg/utils/email.go
+++ b/avent-webrtc-bridge/pkg/utils/email.go
@@ -1,0 +1,17 @@
+package utils
+
+import "strings"
+
+// MaskEmail returns a PII-light representation of an email suitable for logs.
+//
+// "andrea.cervesato@dontouch.ch" becomes "a***@dontouch.ch". The domain is
+// preserved (useful for diagnosing Tuya regional issues) and the local-part is
+// reduced to its first character. Inputs that do not look like an email
+// (missing @, leading @, trailing @) collapse to "***".
+func MaskEmail(email string) string {
+	at := strings.Index(email, "@")
+	if at <= 0 || at == len(email)-1 {
+		return "***"
+	}
+	return email[:1] + "***" + email[at:]
+}

--- a/avent-webrtc-bridge/pkg/utils/email_test.go
+++ b/avent-webrtc-bridge/pkg/utils/email_test.go
@@ -1,0 +1,22 @@
+package utils
+
+import "testing"
+
+func TestMaskEmail(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"andrea.cervesato@dontouch.ch", "a***@dontouch.ch"},
+		{"a@b.co", "a***@b.co"},
+		{"", "***"},
+		{"noatsign", "***"},
+		{"@leading.com", "***"},
+		{"trailing@", "***"},
+	}
+	for _, c := range cases {
+		got := MaskEmail(c.in)
+		if got != c.want {
+			t.Errorf("MaskEmail(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/aventproxy-bridge-addon/run.sh
+++ b/aventproxy-bridge-addon/run.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-# Try HA integration config first (auto-configured), then add-on options
-# Supports both legacy single file and new per-entry files
 BRIDGE_CONFIG_GLOB="/config/philips_avent_bridge_*.json"
 BRIDGE_CONFIG_LEGACY="/config/philips_avent_bridge.json"
 ADDON_CONFIG="/data/options.json"
@@ -30,41 +28,14 @@ if [ -n "$FOUND_CONFIG" ]; then
 elif [ -f "$ADDON_CONFIG" ]; then
     echo "Using add-on options config"
     CONFIG_PATH="$ADDON_CONFIG"
-fi
-
-SIGNING_KEY=$(jq -r '.signing_key' "$CONFIG_PATH")
-SID=$(jq -r '.sid' "$CONFIG_PATH")
-ECODE=$(jq -r '.ecode' "$CONFIG_PATH")
-PARTNER=$(jq -r '.partner' "$CONFIG_PATH")
-APP_KEY=$(jq -r '.app_key' "$CONFIG_PATH")
-DEVICE_ID=$(jq -r '.device_id' "$CONFIG_PATH")
-PACKAGE_NAME=$(jq -r '.package_name' "$CONFIG_PATH")
-
-NUM_CAMERAS=$(jq '.cameras | length' "$CONFIG_PATH")
-
-if [ -z "$SIGNING_KEY" ] || [ "$SIGNING_KEY" = "null" ]; then
-    echo "ERROR: signing_key not configured"
-    echo "Configure the Philips Avent integration first, or set add-on options manually."
+else
+    echo "ERROR: no bridge config found"
     exit 1
 fi
-
-if [ "$NUM_CAMERAS" = "0" ] || [ "$NUM_CAMERAS" = "null" ]; then
-    echo "ERROR: no cameras configured"
-    exit 1
-fi
-
-# For now, use the first camera. Multi-camera: would need multiple bridge instances or
-# modify avent-webrtc-bridge to accept multiple cameras.
-CAMERA_ID=$(jq -r '.cameras[0].camera_id' "$CONFIG_PATH")
-CAMERA_NAME=$(jq -r '.cameras[0].camera_name // "camera"' "$CONFIG_PATH")
 
 echo "=============================="
 echo "Philips Avent WebRTC Bridge"
-echo "=============================="
-PORT=$(jq -r '.bridge_port // 38554' "$CONFIG_PATH")
-
-echo "Camera: $CAMERA_NAME ($CAMERA_ID)"
-echo "RTSP:   rtsp://localhost:$PORT/$CAMERA_NAME"
+echo "Config: $CONFIG_PATH"
 echo "=============================="
 
 CONFIG_HASH=$(md5sum "$CONFIG_PATH" | cut -d' ' -f1)
@@ -80,14 +51,4 @@ CONFIG_HASH=$(md5sum "$CONFIG_PATH" | cut -d' ' -f1)
     done
 ) &
 
-exec avent-webrtc-bridge direct \
-    --signing-key "$SIGNING_KEY" \
-    --sid "$SID" \
-    --ecode "$ECODE" \
-    --partner "$PARTNER" \
-    --app-key "$APP_KEY" \
-    --device-id "$DEVICE_ID" \
-    --package "$PACKAGE_NAME" \
-    --camera-id "$CAMERA_ID" \
-    --camera-name "$CAMERA_NAME" \
-    --port "$PORT"
+exec avent-webrtc-bridge addon --config "$CONFIG_PATH"

--- a/custom_components/philips_avent/camera.py
+++ b/custom_components/philips_avent/camera.py
@@ -8,7 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_BRIDGE_PORT, DEFAULT_BRIDGE_PORT, DOMAIN
+from .const import CONF_BRIDGE_PORT, DEFAULT_BRIDGE_PORT, DOMAIN, sanitize_rtsp_path
 from .coordinator import PhilipsAventCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -37,7 +37,7 @@ class AventCamera(Camera):
         self.coordinator = coordinator
         self._cam_id = cam_id
         self._attr_unique_id = f"{cam_id}_camera"
-        safe_name = coordinator.camera_name.replace(" ", "_")
+        safe_name = sanitize_rtsp_path(coordinator.camera_name, cam_id)
         self._stream_url = f"rtsp://localhost:{bridge_port}/{safe_name}"
         self._attr_device_info = {
             "identifiers": {(DOMAIN, cam_id)},

--- a/custom_components/philips_avent/const.py
+++ b/custom_components/philips_avent/const.py
@@ -85,3 +85,21 @@ CONF_CAMERA_ID = "camera_id"
 CONF_CAMERA_NAME = "camera_name"
 CONF_BRIDGE_PORT = "bridge_port"
 DEFAULT_BRIDGE_PORT = 38554
+
+
+def sanitize_rtsp_path(name: str, cam_id: str) -> str:
+    """Convert a camera display name into an RTSP path component.
+
+    Spaces, forward slashes and backslashes are replaced with underscores.
+    If the result is empty or consists only of an underscore, falls back to
+    the camera id. Returns the path component WITHOUT a leading slash; the
+    caller composes the URL.
+
+    Mirrors `pkg/storage/path.go::SanitizeRTSPPath` in the Go bridge. The two
+    helpers MUST stay in sync — they determine whether the integration's RTSP
+    URL matches the path the bridge serves.
+    """
+    safe = name.replace(" ", "_").replace("/", "_").replace("\\", "_")
+    if safe == "" or safe == "_":
+        safe = cam_id
+    return safe

--- a/tests/test_philips_avent/test_sanitize.py
+++ b/tests/test_philips_avent/test_sanitize.py
@@ -1,0 +1,30 @@
+from const import sanitize_rtsp_path
+
+
+def test_simple_name():
+    assert sanitize_rtsp_path("Erik", "abc123") == "Erik"
+
+
+def test_name_with_spaces():
+    assert sanitize_rtsp_path("Baby Room", "abc123") == "Baby_Room"
+
+
+def test_name_with_slash():
+    assert sanitize_rtsp_path("Baby/Room", "abc123") == "Baby_Room"
+
+
+def test_name_with_backslash():
+    assert sanitize_rtsp_path("Baby\\Room", "abc123") == "Baby_Room"
+
+
+def test_empty_name_falls_back_to_id():
+    assert sanitize_rtsp_path("", "abc123") == "abc123"
+
+
+def test_underscore_only_falls_back_to_id():
+    # Name made entirely of separators sanitizes to "_" → use id instead
+    assert sanitize_rtsp_path("/", "abc123") == "abc123"
+
+
+def test_multiple_spaces():
+    assert sanitize_rtsp_path("Erik  Two", "abc123") == "Erik__Two"


### PR DESCRIPTION
## Summary

Fixes #35. Previously the addon served only `cameras[0]` even though the HA integration already discovered every monitor on the account.

- New `addon` subcommand on the Go bridge that reads the JSON written by the integration and serves every camera from one process, each on its own RTSP path.
- Shared `SanitizeRTSPPath` helper (`pkg/storage/path.go`) used by both `direct.go` and the new `addon.go`; `GenerateRTSPPath` now delegates to it.
- `assignPaths` handles path collisions (suffix with up to 6 chars of camera id) and dedupes duplicate `camera_id` entries (first-entry-wins + warn).
- Python `sanitize_rtsp_path` in `const.py` mirrors the Go helper so `camera.py` produces matching RTSP URLs.
- `aventproxy-bridge-addon/run.sh` reduced to a one-line `exec avent-webrtc-bridge addon --config "$CONFIG_PATH"`; md5 watcher preserved.
- Zero changes required from existing users: single-camera setups keep working unchanged, the JSON schema gained no required fields, the legacy `philips_avent_bridge.json` filename is still recognized.

## What does NOT change

- `cmd/direct` (single-camera dev/test tool) — only swapped to use the shared path helper.
- Multi-arch CI workflows.
- The HA config flow — users still only enter email + password + MFA.

## Test Plan

- [x] Go unit tests: `pkg/storage/path_test.go` (sanitization, slash/backslash, fallback) and `cmd/addon/addon_test.go` (loadConfig, validateConfig with all required fields, assignPaths with collision/dedup/missing-id branches) — 15 tests pass in `golang:1.26-bookworm`.
- [x] Python unit tests: `tests/test_philips_avent/test_sanitize.py` (parity with Go cases) — 80 pass total.
- [x] Ruff lint: clean.
- [x] Addon docker build (mirrors CI `docker-addon` job): `aventproxy-bridge:test` builds, binary lists both `addon` and `direct` under `--help`, `addon --help` shows required `--config` flag.
- [x] Smoke run with fake 2-camera JSON: parses + validates + reaches API call (fails at Tuya with bogus creds, as expected — no panic).
- [x] Smoke run with empty creds: clear `invalid config: signing_key is required` error before any network call.
- [ ] Real-deployment validation by the maintainer: deploy build on HA with the actual Avent monitor(s), confirm RTSP stream works at `rtsp://host:38554/<sanitized-name>`.

## Design docs

- Spec: `docs/superpowers/specs/2026-05-29-multi-camera-bridge-design.md`
- Plan: `docs/superpowers/plans/2026-05-29-multi-camera-bridge.md`

## Follow-ups (non-blocking, noted by final review)

- Test for "collision fallback collides with an organic name" (regression guard).
- Unicode/accent handling in RTSP paths.
- Split `cmd/addon/addon.go` (types / paths / command) if it grows beyond ~250 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add-on mode for ingesting bridge config to register multiple cameras and expose them via per-camera RTSP paths.

* **Improvements**
  * Support multiple Philips Avent monitors on a single account with distinct RTSP paths on the same port.
  * Improved RTSP path sanitization for names with spaces/special chars.
  * Masked user emails in logs for privacy.

* **Documentation**
  * Updated architecture docs/README to show multi-camera port/path layout.

* **Tests**
  * New unit tests covering sanitization, path assignment, config loading, and email masking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thekoma/aventproxy/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->