### PR TITLE
fix: enable camera.snapshot service (closes #39)

### DIFF
--- a/custom_components/philips_avent/camera.py
+++ b/custom_components/philips_avent/camera.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 
 from homeassistant.components.camera import Camera, CameraEntityFeature
+from homeassistant.components.ffmpeg import async_get_image as ffmpeg_get_image
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -48,3 +49,23 @@ class AventCamera(Camera):
 
     async def stream_source(self) -> str:
         return self._stream_url
+
+    async def async_camera_image(
+        self,
+        width: int | None = None,
+        height: int | None = None,
+    ) -> bytes | None:
+        """Pull a single JPEG frame from the live RTSP stream.
+
+        Required by the `camera.snapshot` service. Without this override the
+        base class raises NotImplementedError. The helper runs ffmpeg under
+        the hood; it shares the running bridge stream so it adds no extra
+        load on the camera itself.
+        """
+        try:
+            return await ffmpeg_get_image(
+                self.hass, self._stream_url, width=width, height=height
+            )
+        except Exception:
+            _LOGGER.exception("ffmpeg snapshot failed for %s", self._stream_url)
+            return None


### PR DESCRIPTION
## Summary

Fixes #39 (reported on the [HA community thread](https://community.home-assistant.io/t/641344/42) by Skye).

`AventCamera` declared `CameraEntityFeature.STREAM` but never overrode `async_camera_image`. The base `Camera.camera_image()` raises `NotImplementedError`, so any caller of the `camera.snapshot` service got a Python traceback even though the live RTSP stream itself was running fine.

The override delegates to `homeassistant.components.ffmpeg.async_get_image` — the same helper HA's built-in `generic_camera` uses. It pulls a single JPEG frame from the live RTSP stream the bridge is already serving, so it adds no extra load on the camera device itself.

## What does NOT change

- Live streaming via `stream_source` unchanged.
- No new dependencies — `ffmpeg` is already a HA core component.
- No new entity attributes or config keys.
- Behavior when the bridge isn't running: `async_get_image` will fail, the override catches the exception, logs it, and returns `None`. The service call surfaces "no image available" rather than a Python traceback.

## Test plan

- [x] Ruff lint clean.
- [x] Existing 91 Python tests still pass (this change doesn't touch any tested codepath).
- [ ] Manual verification: deploy `2026.5.2` (or whatever the next release is) on HA, call `camera.snapshot` against the SCD973 dev device, confirm a JPEG lands at the target path.
- [ ] Skye (forum reporter): confirm SCD921 snapshot also works.

This is hard to unit-test because the override pulls in HA's ffmpeg runtime; the existing test suite intentionally avoids loading `homeassistant`. The behavior is verifiable via real deployment only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added camera snapshot capability to the Philips Avent integration, enabling users to capture JPEG images from the live stream with optional resolution customization and robust error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thekoma/aventproxy/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->