### PR TITLE
fix reconnect with active client

### DIFF
--- a/avent-webrtc-bridge/pkg/rtsp/server.go
+++ b/avent-webrtc-bridge/pkg/rtsp/server.go
@@ -77,6 +77,9 @@ type CameraStream struct {
 	active       bool
 	lastActivity time.Time
 
+	// handlingError prevents re-entrant OnError from PeerConnection.Close during teardown.
+	handlingError bool
+
 	// Delayed shutdown
 	shutdownTimer *time.Timer
 	shutdownDelay time.Duration
@@ -84,6 +87,9 @@ type CameraStream struct {
 	// Reference to server for cleanup
 	server   *RTSPServer
 	streamId string
+
+	// startStreamOverride, if set, replaces startStream (tests only).
+	startStreamOverride func()
 }
 
 type ServerConfig struct {
@@ -370,20 +376,7 @@ func (s *RTSPServer) getOrCreateStream(camera *storage.CameraInfo, streamResolut
 		stream.webrtcBridge.SetMQTTClient(mqttClient)
 	}
 
-	stream.webrtcBridge.OnError = func(err error) {
-		if stream.active || stream.connecting {
-			core.Logger.Error().Err(err).Msgf("WebRTC error for camera %s", camera.DeviceName)
-
-			// Only stop if no clients are connected
-			stream.mutex.Lock()
-			clientCount := len(stream.clients)
-			stream.mutex.Unlock()
-
-			if clientCount == 0 {
-				stream.stopStreamInternal()
-			}
-		}
-	}
+	stream.attachBridgeErrorHandler()
 
 	s.streams[streamId] = stream
 
@@ -515,7 +508,11 @@ func (cs *CameraStream) AddClient(client *RTSPClient) {
 	// Start stream if not active and not already connecting
 	if !cs.active && !cs.connecting {
 		cs.connecting = true
-		go cs.startStream()
+		if cs.startStreamOverride != nil {
+			go cs.startStreamOverride()
+		} else {
+			go cs.startStream()
+		}
 	}
 }
 
@@ -577,6 +574,7 @@ func (cs *CameraStream) startStream() {
 
 		// Recreate bridge for retry to get fresh PeerConnection
 		if attempt > 1 {
+			cs.webrtcBridge.OnError = nil
 			cs.webrtcBridge.Stop()
 			cs.webrtcBridge = NewWebRTCBridge(cs.camera, cs.resolution, cs.user, cs.server.storageManager)
 			if cs.server.MobileClient != nil {
@@ -587,17 +585,7 @@ func (cs *CameraStream) startStream() {
 					cs.webrtcBridge.SetMQTTClient(mqttClient)
 				}
 			}
-			cs.webrtcBridge.OnError = func(err error) {
-				if cs.active || cs.connecting {
-					core.Logger.Error().Err(err).Msgf("WebRTC error for camera %s", cs.camera.DeviceName)
-					cs.mutex.Lock()
-					clientCount := len(cs.clients)
-					cs.mutex.Unlock()
-					if clientCount == 0 {
-						cs.stopStreamInternal()
-					}
-				}
-			}
+			cs.attachBridgeErrorHandler()
 		}
 
 		err := cs.webrtcBridge.Start()
@@ -623,6 +611,48 @@ func (cs *CameraStream) stopStream() {
 	cs.stopStreamInternal()
 }
 
+// attachBridgeErrorHandler wires WebRTC OnError to handleBridgeError on the current bridge.
+func (cs *CameraStream) attachBridgeErrorHandler() {
+	if cs.webrtcBridge == nil {
+		return
+	}
+	cs.webrtcBridge.OnError = func(err error) {
+		cs.handleBridgeError(err)
+	}
+}
+
+// handleBridgeError tears down a failed WebRTC session and force-closes RTSP clients
+// so they reconnect against a fresh stream (required for persistent clients like Scrypted).
+func (cs *CameraStream) handleBridgeError(err error) {
+	cs.mutex.Lock()
+	if cs.handlingError || (!cs.active && !cs.connecting) {
+		cs.mutex.Unlock()
+		return
+	}
+	cs.handlingError = true
+
+	core.Logger.Error().Err(err).Msgf("WebRTC error for camera %s", cs.camera.DeviceName)
+
+	clients := make([]*RTSPClient, 0, len(cs.clients))
+	for _, client := range cs.clients {
+		clients = append(clients, client)
+	}
+
+	// Clear OnError before Stop so PeerConnection.Close cannot re-enter this path.
+	if cs.webrtcBridge != nil {
+		cs.webrtcBridge.OnError = nil
+	}
+	cs.stopStreamInternal()
+	cs.handlingError = false
+	cs.mutex.Unlock()
+
+	for _, client := range clients {
+		if client.conn != nil {
+			_ = client.conn.Close()
+		}
+	}
+}
+
 func (cs *CameraStream) stopStreamInternal() {
 	// Check if we should actually stop
 	if !cs.active && !cs.connecting {
@@ -646,6 +676,7 @@ func (cs *CameraStream) stopStreamInternal() {
 
 	// Stop WebRTC bridge (sends SendDisconnect to clean device-side session)
 	if cs.webrtcBridge != nil {
+		cs.webrtcBridge.OnError = nil
 		cs.webrtcBridge.Stop()
 	}
 

--- a/avent-webrtc-bridge/pkg/rtsp/server.go
+++ b/avent-webrtc-bridge/pkg/rtsp/server.go
@@ -384,13 +384,19 @@ func (s *RTSPServer) getOrCreateStream(camera *storage.CameraInfo, streamResolut
 	return stream, nil
 }
 
-func (s *RTSPServer) removeStream(streamId string) {
+// removeStream deletes stream from the server map only if it is still the
+// registered instance for that streamId. A stale async cleanup must not remove
+// a replacement CameraStream that reconnected under the same id.
+func (s *RTSPServer) removeStream(stream *CameraStream) {
+	if stream == nil {
+		return
+	}
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	if _, exists := s.streams[streamId]; exists {
-		delete(s.streams, streamId)
-		core.Logger.Trace().Msgf("Removed stream %s from server map", streamId)
+	if existing, exists := s.streams[stream.streamId]; exists && existing == stream {
+		delete(s.streams, stream.streamId)
+		core.Logger.Trace().Msgf("Removed stream %s from server map", stream.streamId)
 	}
 }
 
@@ -682,10 +688,11 @@ func (cs *CameraStream) stopStreamInternal() {
 
 	// MQTT client is NOT closed — kept alive for next stream (matches app behavior)
 
-	// Remove from server map in a separate goroutine to avoid potential deadlock
+	// Remove from server map in a separate goroutine to avoid potential deadlock.
+	// Pass the stream pointer so a stale cleanup cannot delete a replacement.
 	go func() {
 		if cs.server != nil {
-			cs.server.removeStream(cs.streamId)
+			cs.server.removeStream(cs)
 		}
 	}()
 }

--- a/avent-webrtc-bridge/pkg/rtsp/stream_error_test.go
+++ b/avent-webrtc-bridge/pkg/rtsp/stream_error_test.go
@@ -1,0 +1,142 @@
+package rtsp
+
+import (
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"avent-webrtc-bridge/pkg/storage"
+)
+
+func newTestCameraStream(t *testing.T) (*RTSPServer, *CameraStream) {
+	t.Helper()
+	server := NewRTSPServer(0, nil)
+	camera := &storage.CameraInfo{
+		DeviceID:   "testdev",
+		DeviceName: "Test Cam",
+	}
+	user := &storage.UserSession{UserKey: "user1"}
+	stream := NewCameraStream(camera, "hd", user, nil, server)
+	stream.attachBridgeErrorHandler()
+	server.streams[stream.streamId] = stream
+	return server, stream
+}
+
+func waitStreamRemoved(t *testing.T, server *RTSPServer, streamId string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		server.mutex.RLock()
+		_, exists := server.streams[streamId]
+		server.mutex.RUnlock()
+		if !exists {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("stream %s still in server map after timeout", streamId)
+}
+
+func TestHandleBridgeErrorClosesClientsAndClearsActive(t *testing.T) {
+	server, stream := newTestCameraStream(t)
+	stream.active = true
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+
+	client := &RTSPClient{
+		conn:    serverConn,
+		session: "sess1",
+		stream:  stream,
+	}
+	stream.clients[client.session] = client
+
+	stream.handleBridgeError(errors.New("WebRTC connection failed/closed"))
+
+	stream.mutex.RLock()
+	active := stream.active
+	connecting := stream.connecting
+	stream.mutex.RUnlock()
+	if active || connecting {
+		t.Fatalf("expected inactive stream after error, active=%v connecting=%v", active, connecting)
+	}
+
+	waitStreamRemoved(t, server, stream.streamId)
+
+	_ = clientConn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	buf := make([]byte, 1)
+	_, err := clientConn.Read(buf)
+	if err != io.EOF && !errors.Is(err, net.ErrClosed) && err.Error() != "io: read/write on closed pipe" {
+		t.Fatalf("expected closed client conn (EOF), got %v", err)
+	}
+}
+
+func TestHandleBridgeErrorReentrancy(t *testing.T) {
+	server, stream := newTestCameraStream(t)
+	stream.active = true
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+
+	client := &RTSPClient{
+		conn:    serverConn,
+		session: "sess1",
+		stream:  stream,
+	}
+	stream.clients[client.session] = client
+
+	stream.handleBridgeError(errors.New("first"))
+	// Second call must be a no-op (already torn down / handlingError guard).
+	stream.handleBridgeError(errors.New("second"))
+
+	stream.mutex.RLock()
+	active := stream.active
+	handling := stream.handlingError
+	stream.mutex.RUnlock()
+	if active {
+		t.Fatal("expected inactive after errors")
+	}
+	if handling {
+		t.Fatal("handlingError should be cleared after handleBridgeError returns")
+	}
+
+	waitStreamRemoved(t, server, stream.streamId)
+}
+
+func TestAddClientRestartsAfterBridgeError(t *testing.T) {
+	_, stream := newTestCameraStream(t)
+	stream.active = true
+
+	started := make(chan struct{}, 1)
+	stream.startStreamOverride = func() {
+		started <- struct{}{}
+	}
+
+	stream.handleBridgeError(errors.New("WebRTC connection failed/closed"))
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	client := &RTSPClient{
+		conn:    serverConn,
+		session: "sess2",
+		stream:  stream,
+	}
+	stream.AddClient(client)
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("AddClient did not restart stream after bridge error")
+	}
+
+	stream.mutex.RLock()
+	connecting := stream.connecting
+	stream.mutex.RUnlock()
+	if !connecting {
+		t.Fatal("expected connecting=true after AddClient on inactive stream")
+	}
+}

--- a/avent-webrtc-bridge/pkg/rtsp/stream_error_test.go
+++ b/avent-webrtc-bridge/pkg/rtsp/stream_error_test.go
@@ -105,6 +105,40 @@ func TestHandleBridgeErrorReentrancy(t *testing.T) {
 	waitStreamRemoved(t, server, stream.streamId)
 }
 
+func TestRemoveStreamSkipsReplacementInstance(t *testing.T) {
+	server, oldStream := newTestCameraStream(t)
+	oldStream.active = true
+
+	// Simulate teardown scheduling async remove, then a fast reconnect
+	// registering a new CameraStream under the same streamId.
+	oldStream.stopStreamInternal()
+
+	replacement := NewCameraStream(oldStream.camera, oldStream.resolution, oldStream.user, nil, server)
+	replacement.active = true
+	server.mutex.Lock()
+	server.streams[replacement.streamId] = replacement
+	server.mutex.Unlock()
+
+	// Stale cleanup from the old stream must not delete the replacement.
+	server.removeStream(oldStream)
+
+	server.mutex.RLock()
+	got := server.streams[replacement.streamId]
+	server.mutex.RUnlock()
+	if got != replacement {
+		t.Fatalf("stale removeStream deleted replacement stream")
+	}
+
+	// Cleanup of the live instance still works.
+	server.removeStream(replacement)
+	server.mutex.RLock()
+	_, exists := server.streams[replacement.streamId]
+	server.mutex.RUnlock()
+	if exists {
+		t.Fatal("expected replacement stream to be removed by its own cleanup")
+	}
+}
+
 func TestAddClientRestartsAfterBridgeError(t *testing.T) {
 	_, stream := newTestCameraStream(t)
 	stream.active = true


### PR DESCRIPTION
https://github.com/thekoma/aventproxy/issues/68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebRTC error recovery for camera streams.
  * Disconnects affected RTSP clients after a stream failure so they can reconnect to a fresh stream.
  * Prevents repeated error handling during stream shutdown and restart.

* **Tests**
  * Added coverage for client disconnection, safe error handling, stream removal, and automatic restart behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->