### PR TITLE
fix(rtsp): unblock SD H264 stream startup

### DIFF
--- a/avent-webrtc-bridge/pkg/rtsp/bridge.go
+++ b/avent-webrtc-bridge/pkg/rtsp/bridge.go
@@ -399,20 +399,7 @@ func (wb *WebRTCBridge) setupPeerConnection(webRTCConfig *tuya.WebRTCConfig) err
 	}
 
 	// Setup connection state handler
-	wb.peerConnection.OnConnectionStateChange(func(state pion.PeerConnectionState) {
-		if state == pion.PeerConnectionStateFailed || state == pion.PeerConnectionStateClosed {
-			wb.handleError(errors.New("WebRTC connection failed/closed"))
-		}
-
-		if state == pion.PeerConnectionStateConnected {
-			core.Logger.Info().Msgf("WebRTC connection established")
-
-			if !wb.isHEVC && wb.resolution == "hd" {
-				_ = wb.cameraClient.SendResolution(0)
-				wb.waiter.Done(nil)
-			}
-		}
-	})
+	wb.peerConnection.OnConnectionStateChange(wb.handlePeerConnectionStateChange)
 
 	// Setup track handler for incoming media if not HEVC
 	wb.peerConnection.OnTrack(func(track *pion.TrackRemote, receiver *pion.RTPReceiver) {
@@ -450,6 +437,23 @@ func (wb *WebRTCBridge) setupPeerConnection(webRTCConfig *tuya.WebRTCConfig) err
 	})
 
 	return nil
+}
+
+func (wb *WebRTCBridge) handlePeerConnectionStateChange(state pion.PeerConnectionState) {
+	if state == pion.PeerConnectionStateFailed || state == pion.PeerConnectionStateClosed {
+		wb.handleError(errors.New("WebRTC connection failed/closed"))
+	}
+
+	if state == pion.PeerConnectionStateConnected {
+		core.Logger.Info().Msgf("WebRTC connection established")
+
+		if !wb.isHEVC {
+			if wb.resolution == "hd" {
+				_ = wb.cameraClient.SendResolution(0)
+			}
+			wb.waiter.Done(nil)
+		}
+	}
 }
 
 func (wb *WebRTCBridge) setupMQTTCameraClient(webRTCConfig *tuya.WebRTCConfig) {

--- a/avent-webrtc-bridge/pkg/rtsp/bridge_test.go
+++ b/avent-webrtc-bridge/pkg/rtsp/bridge_test.go
@@ -1,0 +1,27 @@
+package rtsp
+
+import (
+	"testing"
+	"time"
+
+	pion "github.com/pion/webrtc/v4"
+)
+
+func TestHandlePeerConnectionStateChangeUnblocksSDH264(t *testing.T) {
+	wb := &WebRTCBridge{
+		resolution: "sd",
+		isHEVC:     false,
+	}
+
+	wait := wb.waiter.WaitChan()
+	wb.handlePeerConnectionStateChange(pion.PeerConnectionStateConnected)
+
+	select {
+	case err := <-wait:
+		if err != nil {
+			t.Fatalf("expected successful connection, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SD H264 connection did not unblock the bridge waiter")
+	}
+}


### PR DESCRIPTION
## Summary

- unblock non-HEVC SD stream startup after the WebRTC peer connection reaches `Connected`
- keep the HD-only `SendResolution(0)` behavior unchanged
- add a regression test for the SD H264 waiter path

## Root cause

`WebRTCBridge.Start()` waits for `wb.waiter`. The peer connection callback only completed that waiter for non-HEVC HD streams. A non-HEVC SD stream could transport media, but `Start()` never returned. The owning `CameraStream` therefore remained locked and later RTSP clients blocked before receiving responses.

This is the same control-flow defect described in seydx/tuya-ipc-terminal#27 and fixed there by seydx/tuya-ipc-terminal#28.

## Verification

Before the fix:

```text
--- FAIL: TestHandlePeerConnectionStateChangeUnblocksSDH264 (1.00s)
SD H264 connection did not unblock the bridge waiter
```

After the fix:

- `go test ./...`
- `go test -race ./...`
- `go build -o avent-webrtc-bridge .`
- binary `--help` smoke test

Live validation used an isolated Home Assistant test add-on built from this commit:

- the SD H264 bridge logged `WebRTC bridge started successfully`
- Scrypted remained connected as the persistent first RTSP client
- two later RTSP clients each completed setup and received a 1280x720 frame
- Scrypted keepalives continued receiving `200 OK` responses
- a HomeKit session remained active during the validation window
- the stable add-on was restored after the test

No camera names, addresses, credentials, or session identifiers are included here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebRTC connection handling for standard H.264 streams at SD resolution.
  * Connections now complete successfully without waiting unnecessarily for an HD-specific command.

* **Tests**
  * Added coverage to verify that SD H.264 connections complete promptly and without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->